### PR TITLE
TableRepairOrders populates and made many ineffectual changes

### DIFF
--- a/src/core/RepairOrder.java
+++ b/src/core/RepairOrder.java
@@ -22,7 +22,7 @@ public class RepairOrder
         shipIn_CID = 0;
         EID = 0;
     }
-    public RepairOrder(int r, String dr, String ds, String st, int sc, int sc2, int e)
+    public RepairOrder(int r, String dr, String ds, String st, int sc,int e, int sc2)
     {
         RID = r;
         dateRecd = dr;

--- a/src/dao/RepairOrderDAO.java
+++ b/src/dao/RepairOrderDAO.java
@@ -50,13 +50,13 @@ public class RepairOrderDAO {
 //            stmt.setString(5, repairOrder.dateRecd);
 //            stmt.setString(6, repairOrder.dateShipped);
 //            stmt.setString(7, repairOrder.shipOutType);
-            stmt.setInt(1, repairOrder.getShipOut_CID());
-            stmt.setInt(2, repairOrder.getShipIn_CID());
-            stmt.setInt(3, repairOrder.getEID());
-            stmt.setInt(4, repairOrder.getRID());
-            stmt.setString(5, repairOrder.getDateRecd());
-            stmt.setString(6, repairOrder.getDateShipped());
-            stmt.setString(7, repairOrder.getShipOutType());
+            stmt.setInt(1, repairOrder.getRID());
+            stmt.setString(2, repairOrder.getDateRecd());
+            stmt.setString(3, repairOrder.getDateShipped());
+            stmt.setString(4, repairOrder.getShipOutType());
+            stmt.setInt(5, repairOrder.getShipOut_CID());
+            stmt.setInt(6, repairOrder.getEID());
+            stmt.setInt(7, repairOrder.getShipIn_CID());
             stmt.execute();
         } finally {
             conn.close(stmt, null);
@@ -92,13 +92,13 @@ public class RepairOrderDAO {
 //            stmt.setString(5, repairOrder.dateRecd);
 //            stmt.setString(6, repairOrder.dateShipped);
 //            stmt.setString(7, repairOrder.shipOutType);
-            stmt.setInt(1, repairOrder.getShipOut_CID());
-            stmt.setInt(2, repairOrder.getShipIn_CID());
-            stmt.setInt(3, repairOrder.getEID());
-            stmt.setInt(4, repairOrder.getRID());
-            stmt.setString(5, repairOrder.getDateRecd());
-            stmt.setString(6, repairOrder.getDateShipped());
-            stmt.setString(7, repairOrder.getShipOutType());
+            stmt.setInt(1, repairOrder.getRID());
+            stmt.setString(2, repairOrder.getDateRecd());
+            stmt.setString(3, repairOrder.getDateShipped());
+            stmt.setString(4, repairOrder.getShipOutType());
+            stmt.setInt(5, repairOrder.getShipOut_CID());
+            stmt.setInt(6, repairOrder.getEID());
+            stmt.setInt(7, repairOrder.getShipIn_CID());
             stmt.execute();
         } finally {
             conn.close(stmt, null);
@@ -106,6 +106,7 @@ public class RepairOrderDAO {
     }
     
     private RepairOrder convertRowToRepairOrder(ResultSet rs) throws Exception {
+        int RID = rs.getInt("RID");
         String dateRecd = rs.getString("dateRecd");
         String dateShipped = rs.getString("dateShipped");
         String shipOutType = rs.getString("shipOutType");
@@ -116,7 +117,6 @@ public class RepairOrderDAO {
 //        int shipOut_CID = rs.getInt("shipOut_CID");
 //        int EID = rs.getInt("EID");
 //        int shipIn_CID = rs.getInt("shipIn_CID");
-        int RID = rs.getInt("RID");
-        return new RepairOrder();
+        return new RepairOrder(RID, dateRecd, dateShipped, shipOutType, shipOut_CID, EID, shipIn_CID);
     }
 }

--- a/src/gui/RepairOrderFrame.form
+++ b/src/gui/RepairOrderFrame.form
@@ -217,12 +217,12 @@
             <Property name="model" type="javax.swing.table.TableModel" editor="org.netbeans.modules.form.editors2.TableModelEditor">
               <Table columnCount="7" rowCount="5">
                 <Column editable="true" title="RID" type="java.lang.Integer"/>
-                <Column editable="true" title="dateShipped" type="java.lang.String"/>
-                <Column editable="true" title="dateRecd" type="java.lang.String"/>
+                <Column editable="true" title="dateRecd" type="java.lang.Object"/>
+                <Column editable="true" title="dateShipped" type="java.lang.Object"/>
                 <Column editable="true" title="shipOutType" type="java.lang.String"/>
                 <Column editable="true" title="shipOut_CID" type="java.lang.Integer"/>
-                <Column editable="true" title="receivingEID" type="java.lang.Integer"/>
-                <Column editable="true" title="CID" type="java.lang.Integer"/>
+                <Column editable="true" title="EID" type="java.lang.Integer"/>
+                <Column editable="true" title="shipIn_CID" type="java.lang.Integer"/>
               </Table>
             </Property>
             <Property name="columnModel" type="javax.swing.table.TableColumnModel" editor="org.netbeans.modules.form.editors2.TableColumnModelEditor">

--- a/src/gui/RepairOrderFrame.java
+++ b/src/gui/RepairOrderFrame.java
@@ -11,8 +11,8 @@ import dao.RepairOrderDAO;
 import dao.DBConnection;
 
 // **** //
-//import java.util.logging.Level;
-//import java.util.logging.Logger;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.swing.JOptionPane;
 // **** //
 
@@ -31,25 +31,25 @@ public class RepairOrderFrame extends javax.swing.JFrame {
     public RepairOrderFrame(DBConnection myConn) {
         initComponents();
         
+        conn = myConn;
+        RODAO = new RepairOrderDAO(conn);
         // enable column sorting on any attribute in the table
         // follows from https://github.com/LegendaryZReborn/4123-DatabaseManagement/blob/master/Donation%20Tracker/src/gui/FundFrame.java
         TableRepairOrders.setAutoCreateRowSorter(true);
-        
-        conn = myConn;
-        RODAO = new RepairOrderDAO(conn);
-        
         try {
             repairOrders = RODAO.getAllRepairOrders();
             model = new RepairOrderTableModel(repairOrders);
             TableRepairOrders.setModel(model);
         }
         catch(Exception ex) {
+            Logger.getLogger(RepairOrderFrame.class.getName()).log(Level.SEVERE, null, ex);
             JOptionPane.showMessageDialog(this, "Error 2: " + ex, "Error", JOptionPane.ERROR_MESSAGE);
         }
 //        catch(Exception ex) {
 //            Logger.getLogger(ContributionFrame.class.getName()).log(Level.SEVERE, null, ex);
 //            JOptionPane.showMessageDialog(this, "Error 2: " + ex, "Error", JOptionPane.ERROR_MESSAGE);
 //        }
+        
     }
 
     /**
@@ -111,11 +111,11 @@ public class RepairOrderFrame extends javax.swing.JFrame {
                 {null, null, null, null, null, null, null}
             },
             new String [] {
-                "RID", "dateShipped", "dateRecd", "shipOutType", "shipOut_CID", "receivingEID", "CID"
+                "RID", "dateRecd", "dateShipped", "shipOutType", "shipOut_CID", "EID", "shipIn_CID"
             }
         ) {
             Class[] types = new Class [] {
-                java.lang.Integer.class, java.lang.String.class, java.lang.String.class, java.lang.String.class, java.lang.Integer.class, java.lang.Integer.class, java.lang.Integer.class
+                java.lang.Integer.class, java.lang.Object.class, java.lang.Object.class, java.lang.String.class, java.lang.Integer.class, java.lang.Integer.class, java.lang.Integer.class
             };
 
             public Class getColumnClass(int columnIndex) {

--- a/src/gui/RepairOrderTableModel.java
+++ b/src/gui/RepairOrderTableModel.java
@@ -16,14 +16,14 @@ import javax.swing.table.AbstractTableModel;
  */
 public class RepairOrderTableModel extends AbstractTableModel{
     private static final int RID_COL = 0;
-    private static final int dateRecd_COL = 6;
-    private static final int dateShipped_COL = 5;
+    private static final int dateRecd_COL = 2;
+    private static final int dateShipped_COL = 3;
     private static final int shipOutType_COL = 4;
-    private static final int shipOut_CID_COL = 3;
-    private static final int shipIn_CID_COL = 2;
-    private static final int EID_COL = 1;  
-    private String[] columnNames = {"RID", "EID", "ShipIn CID",
-        "ShipOut CID", "shipOutType", "dateShipped", "dateRecd"};
+    private static final int shipOut_CID_COL = 5;
+    private static final int shipIn_CID_COL = 7;
+    private static final int EID_COL = 6;  
+    private String[] columnNames = {"RID", "dateRecd", "dateShipped",
+        "shipOutType", "shipOut_CID", "EID", "shipIn_CID"};
     private List<RepairOrder> repairOrder;
     
     public RepairOrderTableModel(List<RepairOrder> rpo){
@@ -47,40 +47,42 @@ public class RepairOrderTableModel extends AbstractTableModel{
         switch (col) {
             case RID_COL:
                 return tempOrder.getRID();
-            case EID_COL:
-                return tempOrder.getEID();
-            case shipOutType_COL:
-                return tempOrder.getShipOutType();
-            case shipIn_CID_COL:
-                return tempOrder.getShipIn_CID();
-            case shipOut_CID_COL:
-                return tempOrder.getShipOut_CID();
-            case dateShipped_COL:
-                return tempOrder.getDateShipped();
             case dateRecd_COL:
                 return tempOrder.getDateRecd();
+            case dateShipped_COL:
+                return tempOrder.getDateShipped();
+            case shipOutType_COL:
+                return tempOrder.getShipOutType();
+            case shipOut_CID_COL:
+                return tempOrder.getShipOut_CID();
+            case EID_COL:
+                return tempOrder.getEID();
+            case shipIn_CID_COL:
+                return tempOrder.getShipIn_CID();
             default:
-                return tempOrder.getEID() + " " + tempOrder.getRID();
+                return tempOrder.getRID();
         }
     }
     
     public void setValueAt(Object val, int row, int col) {
         RepairOrder tempOrder = repairOrder.get(row);
         switch (col) {
-            case EID_COL:
-                tempOrder.setEID((int) val);
-            case dateRecd_COL:
-                tempOrder.setDateRecd((String) val);
             case RID_COL:
                 tempOrder.setRID((int) val);
+            case dateRecd_COL:
+                tempOrder.setDateRecd((String) val);
             case dateShipped_COL:
                 tempOrder.setDateShipped((String) val);
-            case shipIn_CID_COL:
-                tempOrder.setShipIn_CID((int) val);
-            case shipOut_CID_COL:
-                tempOrder.setShipOut_CID((int) val);
             case shipOutType_COL:
                 tempOrder.setShipOutType((String) val);
+            case shipOut_CID_COL:
+                tempOrder.setShipOut_CID((int) val);
+            case EID_COL:
+                tempOrder.setEID((int) val);
+            case shipIn_CID_COL:
+                tempOrder.setShipIn_CID((int) val);
+            default:
+                tempOrder.setRID((int) val);
         }
     }
     


### PR DESCRIPTION
to all RepairOrder files and fixed the Table and error message in the Frame, convertRowToRepairOrder, updateRepairOrder, and addRepairOrder in the DAO, the column numbers and column names in the TableModel due to my misnaming of the table attributes.